### PR TITLE
fix(SUP-37882): Events are not sent to GTM

### DIFF
--- a/.github/workflows/run_canary_full_flow.yaml
+++ b/.github/workflows/run_canary_full_flow.yaml
@@ -10,7 +10,7 @@ on:
 jobs:
   canary-full-flow:
     if: ${{ github.actor != 'PlaykitJs-Bot' }}
-    uses: kaltura/ovp-pipelines-pub/.github/workflows/player_cicd.yaml@v1.0.0
+    uses: kaltura/ovp-pipelines-pub/.github/workflows/player_cicd.yaml@uuid_wa
     secrets:
       PLAYER_CENTRAL_ACCOUNT_ID: ${{ secrets.PLAYER_CENTRAL_ACCOUNT_ID }}
       PLAYER_SERVICES_ACCOUNT_ID: ${{ secrets.PLAYER_SERVICES_ACCOUNT_ID }}

--- a/.github/workflows/run_prod.yaml
+++ b/.github/workflows/run_prod.yaml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   prod:
-    uses: kaltura/ovp-pipelines-pub/.github/workflows/player_cicd.yaml@v1.0.0
+    uses: kaltura/ovp-pipelines-pub/.github/workflows/player_cicd.yaml@uuid_wa
     secrets:
       PLAYER_CENTRAL_ACCOUNT_ID: ${{ secrets.PLAYER_CENTRAL_ACCOUNT_ID }}
       PLAYER_SERVICES_ACCOUNT_ID: ${{ secrets.PLAYER_SERVICES_ACCOUNT_ID }}

--- a/.github/workflows/run_tests.yaml
+++ b/.github/workflows/run_tests.yaml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   running-tests:
-    uses: kaltura/ovp-pipelines-pub/.github/workflows/player_tests.yaml@v1.0.0
+    uses: kaltura/ovp-pipelines-pub/.github/workflows/player_tests.yaml@uuid_wa
     with:
       yarn-run-to-execute: 'build lint:check types:check test'
   notification:

--- a/src/google-tag-manager.ts
+++ b/src/google-tag-manager.ts
@@ -28,7 +28,7 @@ export class GoogleTagManager extends BasePlugin<GoogleTagManagerConfig> {
 
   constructor(name: string, player: KalturaPlayer, config?: GoogleTagManagerConfig) {
     super(name, player, config);
-    if (this.config.containerId.match(/^GTM-[A-Z1-9]{7}$/)) {
+    if (this.config.containerId.match(/^GTM-[A-Z1-9]{1,7}$/)) {
       this.loadTag();
       this.aggregatePlayerEvents();
       this.initCustomEventsListeners();

--- a/src/google-tag-manager.ts
+++ b/src/google-tag-manager.ts
@@ -28,7 +28,7 @@ export class GoogleTagManager extends BasePlugin<GoogleTagManagerConfig> {
 
   constructor(name: string, player: KalturaPlayer, config?: GoogleTagManagerConfig) {
     super(name, player, config);
-    if (this.config.containerId.match(/^GTM-[A-Z1-9]{1,7}$/)) {
+    if (this.config.containerId.match(/^GTM-[A-Z1-9]{2,}$/)) {
       this.loadTag();
       this.aggregatePlayerEvents();
       this.initCustomEventsListeners();


### PR DESCRIPTION
### Description of the Changes

GTM is not activated when the string of the container id contains less than 7 characters.
(It doesn't have to be exactly 7)

solves [SUP-37882](https://github.com/kaltura/playkit-js-google-tag-manager/tree/SUP-37882)

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated


[SUP-37882]: https://kaltura.atlassian.net/browse/SUP-37882?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ